### PR TITLE
Bugfix

### DIFF
--- a/squid_app/squid_asg_construct.py
+++ b/squid_app/squid_asg_construct.py
@@ -17,7 +17,7 @@ class SquidAsgConstruct(core.Construct):
         squid_iam_role = iam.Role(self,"squid-role", 
           assumed_by=iam.ServicePrincipal("ec2.amazonaws.com"),
           managed_policies=[iam.ManagedPolicy.from_aws_managed_policy_name("CloudWatchAgentServerPolicy"),
-          iam.ManagedPolicy.from_aws_managed_policy_name("service-role/AmazonEC2RoleforSSM")]
+          iam.ManagedPolicy.from_aws_managed_policy_name("AmazonSSMManagedInstanceCore")]
         )
         
         # Add policy to allow EC2 update instance attributes
@@ -143,7 +143,7 @@ class SquidAsgConstruct(core.Construct):
                         route_table_ids=subnet.route_table.route_table_id
                 
                 # Tag the ASG with route table ids
-                core.Tag.add(asg,
+                core.Tags.of(asg).add(
                         key='RouteTableIds',
                         value=route_table_ids,
                         apply_to_launched_instances=False

--- a/squid_app/test_instance_stack.py
+++ b/squid_app/test_instance_stack.py
@@ -19,10 +19,11 @@ class TestInstanceStack(core.Stack):
 
         # Create a role for the instance and attach the SSM Managed Policy to this role.
         instance_role = iam.Role(self, "test-instance-SSM-role", 
-            assumed_by=iam.ServicePrincipal("ec2.amazonaws.com")
+            assumed_by=iam.ServicePrincipal("ec2.amazonaws.com"),
+            managed_policies=[
+                iam.ManagedPolicy.from_aws_managed_policy_name("CloudWatchAgentServerPolicy"),
+                iam.ManagedPolicy.from_aws_managed_policy_name("AmazonSSMManagedInstanceCore")]
         )
-
-        instance_role.add_managed_policy(iam.ManagedPolicy.from_aws_managed_policy_name("service-role/AmazonEC2RoleforSSM"))
 
         # Create a test instance in any available private subnet allowing all outbound connections. No inbound connections allowed.
         instance = ec2.Instance(self, "test-instance",


### PR DESCRIPTION
### Changes

* The role `AmazonEC2RoleforSSM` has been retired (it granted access to far too many resources). Replaced it with `AmazonSSMManagedInstanceCore`.
* The syntax on `Tags.add()` has changed slightly, so I updated it to get the warning to go away.
* I added VPC Endpoints for
  * S3
  * SSM
  * CloudWatch Logs


> By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
