### PR TITLE
fixed circular dependency

### DIFF
--- a/squid_app/squid_stack.py
+++ b/squid_app/squid_stack.py
@@ -35,7 +35,6 @@ class SquidStack(core.Stack):
         #  2. SNS topic where change in alarm state is published 
 
         monitoring = SquidMonitoringConstruct(self,"squid-monitoring", squid_asgs=asgs.squid_asgs)
-        monitoring.node.add_dependency(lambda_function)
 
         # Add SNS subscription to tie the Lambda and CloudWatch alarm 
         lambda_function.add_sns_subscription(lambda_function=lambda_function.squid_alarm_lambda_function, squid_alarm_topic=monitoring.squid_alarm_topic)


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Fixed the following error when deploying squid stack
```
 ❌  squid failed: Error [ValidationError]: Circular dependency between resources: [squidlambdaalarmfunctionE014E39E, squidmonitoringsquidalarm1C2BBA36D, squidmonitoringsquidasgalarmtopic01DF7A9B, squidlambdaalarmfunctionsquidasgalarmtopicED9A6136, squidlambdaalarmfunctionAllowInvokesquidsquidmonitoringsquidasgalarmtopicD15361F8236A741B, squidlambdaalarmfunctionsquidlambdapermission61991026, squidmonitoringsquidalarm2ABEEAEBF]
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
